### PR TITLE
Expand gameplay area to full screen when running

### DIFF
--- a/app/static/game.js
+++ b/app/static/game.js
@@ -101,7 +101,10 @@ function spawnFood(snake) {
   return available[Math.floor(Math.random() * available.length)];
 }
 
-function resetGame() {
+function resetGame({ keepExpandedLayout = false } = {}) {
+  if (!keepExpandedLayout) {
+    document.body.classList.remove('game-active');
+  }
   state = createInitialState();
   updateScoreboard();
   draw();
@@ -122,6 +125,7 @@ function startGame() {
   if (state.running) {
     return;
   }
+  document.body.classList.add('game-active');
   state.running = true;
   paused = false;
   overlay.classList.add('hidden');
@@ -416,7 +420,7 @@ startButton.addEventListener('click', startGame);
 pauseButton.addEventListener('click', pauseGame);
 overlayButton.addEventListener('click', () => {
   if (!state.running) {
-    resetGame();
+    resetGame({ keepExpandedLayout: true });
     startGame();
   } else {
     pauseGame();

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -14,6 +14,10 @@
   box-sizing: border-box;
 }
 
+html {
+  height: 100%;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -25,6 +29,12 @@ body {
   position: relative;
   overflow-x: hidden;
   overscroll-behavior: none;
+}
+
+body.game-active {
+  min-height: 100vh;
+  align-items: stretch;
+  justify-content: stretch;
 }
 
 .background-layer {
@@ -52,12 +62,32 @@ body {
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
 }
 
+body.game-active .app-shell {
+  width: 100vw;
+  height: 100vh;
+  padding: clamp(1rem, 2vw, 2rem);
+  background: transparent;
+  border-radius: 0;
+  border: none;
+  backdrop-filter: none;
+  box-shadow: none;
+  grid-template-rows: auto 1fr;
+}
+
 .hud {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
+}
+
+body.game-active .hud {
+  background: rgba(8, 12, 20, 0.75);
+  border-radius: 18px;
+  padding: 0.75rem 1.5rem;
+  border: 1px solid rgba(110, 245, 255, 0.25);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
 }
 
 .scoreboard {
@@ -127,6 +157,11 @@ body {
   box-shadow: inset 0 0 0 1px rgba(110, 245, 255, 0.08);
 }
 
+body.game-active .board-wrapper {
+  height: 100%;
+  border-radius: 20px;
+}
+
 #game-board {
   width: 100%;
   height: auto;
@@ -134,6 +169,10 @@ body {
   background: rgba(8, 12, 20, 0.85);
   image-rendering: pixelated;
   touch-action: none;
+}
+
+body.game-active #game-board {
+  height: 100%;
 }
 
 .overlay {
@@ -178,6 +217,10 @@ body {
   padding: 1.5rem;
   border: 1px solid rgba(239, 243, 255, 0.08);
   box-shadow: inset 0 0 0 1px rgba(110, 245, 255, 0.05);
+}
+
+body.game-active .info-panel {
+  display: none;
 }
 
 .info-panel h2 {


### PR DESCRIPTION
## Summary
- add a game-active layout state that lets the board fill the entire viewport while a run is in progress
- toggle the new layout state from the game lifecycle so the experience enlarges automatically after Start

## Testing
- uvicorn app:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68e5262c91388332b777aeb2e266319c