### PR TITLE
Allow snake to wrap around board edges

### DIFF
--- a/app/static/game.js
+++ b/app/static/game.js
@@ -182,6 +182,9 @@ function step() {
     y: state.snake[0].y + state.direction.y,
   };
 
+  newHead.x = (newHead.x + GRID_SIZE) % GRID_SIZE;
+  newHead.y = (newHead.y + GRID_SIZE) % GRID_SIZE;
+
   if (isCollision(newHead)) {
     endGame();
     return;
@@ -202,9 +205,6 @@ function step() {
 }
 
 function isCollision(position) {
-  if (position.x < 0 || position.y < 0 || position.x >= GRID_SIZE || position.y >= GRID_SIZE) {
-    return true;
-  }
   return state.snake.some((segment) => segment.x === position.x && segment.y === position.y);
 }
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -49,7 +49,7 @@
         <h2>How to Play</h2>
         <ul>
           <li>Eat the neon fruit to grow your snake and earn points.</li>
-          <li>Avoid colliding with the walls or your own tail.</li>
+          <li>Walls wrap around—only your own tail can end the run.</li>
           <li>Use the pause button or press <kbd>Space</kbd> to pause or resume.</li>
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- wrap new snake head coordinates to the opposite side of the grid
- remove wall collision detection so only self-collisions end the game

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52c316b988332b9d6207421ac5b28