### PR TITLE
Fix game initialization by removing stray function declaration

### DIFF
--- a/app/static/game.js
+++ b/app/static/game.js
@@ -217,7 +217,6 @@ function levelToInterval(level) {
   return Math.max(MIN_SPEED_INTERVAL, Math.min(MAX_SPEED_INTERVAL, interval));
 }
 
-function applySettingsToState() {
 function getDifficultyConfig(difficulty) {
   return DIFFICULTY_CONFIG[difficulty] || DIFFICULTY_CONFIG.easy;
 }


### PR DESCRIPTION
## Summary
- remove an extraneous function declaration in the frontend script that caused a syntax error and prevented the game from initializing

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68e5e398cdf88332bb0e85b7ae58b168