### PR TITLE
Add server-side leaderboard and responsive mobile improvements

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from fastapi import FastAPI
+from typing import List
+
+from fastapi import FastAPI, Query
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field, validator
+
+from .leaderboard import LeaderboardStore, ensure_difficulty, normalize_score, sanitize_name
 
 BASE_DIR = Path(__file__).resolve().parent
 STATIC_DIR = BASE_DIR / "static"
+LEADERBOARD_LIMIT = 100
 
 app = FastAPI(title="Snake Classic")
 
@@ -15,9 +21,64 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 _index_html = (STATIC_DIR / "index.html").read_text(encoding="utf-8")
 
+store = LeaderboardStore(BASE_DIR / "data" / "leaderboard.json", limit=LEADERBOARD_LIMIT)
+
+
+class LeaderboardEntryResponse(BaseModel):
+    name: str
+    score: int
+    difficulty: str
+    submitted_at: str
+
+
+class LeaderboardPayload(BaseModel):
+    entries: List[LeaderboardEntryResponse]
+    total: int
+
+
+class LeaderboardSubmission(BaseModel):
+    name: str = Field(default="Anonymous", max_length=24)
+    score: int = Field(default=0, ge=0)
+    difficulty: str = Field(default="easy")
+
+    @validator("name", pre=True, always=True)
+    def validate_name(cls, value: str | None) -> str:
+        return sanitize_name(value)
+
+    @validator("score", pre=True, always=True)
+    def validate_score(cls, value) -> int:
+        return normalize_score(value)
+
+    @validator("difficulty", pre=True, always=True)
+    def validate_difficulty(cls, value: str | None) -> str:
+        return ensure_difficulty(value)
+
+
+class LeaderboardSubmissionResponse(BaseModel):
+    entries: List[LeaderboardEntryResponse]
+    entry: LeaderboardEntryResponse
+    rank: int | None
+
 
 @app.get("/", response_class=HTMLResponse)
 async def read_index() -> str:
     """Serve the main game page."""
 
     return _index_html
+
+
+@app.get("/api/leaderboard", response_model=LeaderboardPayload)
+async def get_leaderboard(limit: int = Query(10, ge=1, le=LEADERBOARD_LIMIT)) -> LeaderboardPayload:
+    entries = await store.get_entries()
+    limited = entries[:limit]
+    return LeaderboardPayload(entries=limited, total=len(entries))
+
+
+@app.post("/api/leaderboard", response_model=LeaderboardSubmissionResponse, status_code=201)
+async def submit_leaderboard(submission: LeaderboardSubmission) -> LeaderboardSubmissionResponse:
+    entries, entry, rank = await store.submit(
+        name=submission.name,
+        score=submission.score,
+        difficulty=submission.difficulty,
+    )
+    return LeaderboardSubmissionResponse(entries=entries, entry=entry, rank=rank)

--- a/app/leaderboard.py
+++ b/app/leaderboard.py
@@ -1,0 +1,144 @@
+"""Server-side leaderboard persistence utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List
+
+ALLOWED_DIFFICULTIES = {"easy", "medium", "hard"}
+MAX_NAME_LENGTH = 24
+
+
+def sanitize_name(value: str | None) -> str:
+    """Normalize a player name for storage."""
+
+    if not isinstance(value, str):
+        return "Anonymous"
+    cleaned = value.strip()[:MAX_NAME_LENGTH]
+    return cleaned or "Anonymous"
+
+
+def ensure_difficulty(value: str | None) -> str:
+    """Clamp difficulty values to the supported set."""
+
+    if not isinstance(value, str):
+        return "easy"
+    lowered = value.strip().lower()
+    return lowered if lowered in ALLOWED_DIFFICULTIES else "easy"
+
+
+def normalize_score(value: int | float | str) -> int:
+    """Convert arbitrary score input into a bounded integer."""
+
+    try:
+        numeric = int(float(value))
+    except (TypeError, ValueError):
+        numeric = 0
+    return max(0, numeric)
+
+
+@dataclass(slots=True)
+class LeaderboardRecord:
+    """A normalized leaderboard entry."""
+
+    name: str
+    score: int
+    difficulty: str
+    submitted_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "score": self.score,
+            "difficulty": self.difficulty,
+            "submitted_at": self.submitted_at,
+        }
+
+
+class LeaderboardStore:
+    """File-backed leaderboard storage with asyncio-friendly locking."""
+
+    def __init__(self, path: Path, limit: int = 100) -> None:
+        self._path = path
+        self._limit = limit
+        self._lock = asyncio.Lock()
+
+    async def get_entries(self) -> List[dict]:
+        async with self._lock:
+            return [record.to_dict() for record in self._load_records()]
+
+    async def submit(self, *, name: str, score: int, difficulty: str) -> tuple[List[dict], dict, int]:
+        record = LeaderboardRecord(
+            name=sanitize_name(name),
+            score=normalize_score(score),
+            difficulty=ensure_difficulty(difficulty),
+            submitted_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+        async with self._lock:
+            records = self._load_records()
+            records.append(record)
+            records.sort(key=lambda item: (-item.score, item.submitted_at))
+
+            rank = self._rank_of(records, record)
+
+            limited = records[: self._limit]
+            self._save_records(limited)
+
+            return [item.to_dict() for item in limited], record.to_dict(), rank
+
+    def _load_records(self) -> List[LeaderboardRecord]:
+        if not self._path.exists():
+            return []
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return []
+
+        payload = raw.get("entries") if isinstance(raw, dict) else raw
+        if not isinstance(payload, list):
+            return []
+
+        records: List[LeaderboardRecord] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            name = sanitize_name(item.get("name"))
+            score = normalize_score(item.get("score"))
+            difficulty = ensure_difficulty(item.get("difficulty"))
+            submitted_at_raw = item.get("submitted_at")
+            if isinstance(submitted_at_raw, str):
+                submitted_at = submitted_at_raw
+            else:
+                submitted_at = datetime.now(timezone.utc).isoformat()
+            records.append(
+                LeaderboardRecord(
+                    name=name,
+                    score=score,
+                    difficulty=difficulty,
+                    submitted_at=submitted_at,
+                ),
+            )
+
+        records.sort(key=lambda item: (-item.score, item.submitted_at))
+        return records[: self._limit]
+
+    def _save_records(self, records: Iterable[LeaderboardRecord]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        data = {"entries": [record.to_dict() for record in records]}
+        self._path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    @staticmethod
+    def _rank_of(records: List[LeaderboardRecord], record: LeaderboardRecord) -> int:
+        for index, item in enumerate(records):
+            if item.submitted_at == record.submitted_at and item.name == record.name and item.score == record.score:
+                return index + 1
+        extended = sorted(records + [record], key=lambda item: (-item.score, item.submitted_at))
+        for index, item in enumerate(extended):
+            if item.submitted_at == record.submitted_at and item.name == record.name and item.score == record.score:
+                return index + 1
+        return len(records) + 1

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -91,6 +91,14 @@
             <button id="overlay-button" class="btn primary">Continue</button>
           </div>
         </div>
+        <div id="orientation-guard" class="orientation-guard hidden" role="alert" aria-live="assertive">
+          <div class="card">
+            <h2 id="orientation-guard-title">Rotate Device</h2>
+            <p id="orientation-guard-message">
+              Snake Classic works best when your device stays in its starting orientation.
+            </p>
+          </div>
+        </div>
       </section>
 
       <section class="info-panel">

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -58,7 +58,13 @@ body.game-active {
   width: min(100vw - 2rem, 960px);
   padding: 2rem;
   display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  grid-template-areas:
+    'hud hud'
+    'menu board'
+    'info board';
   gap: 1.5rem;
+  align-items: start;
   background: rgba(10, 14, 22, 0.8);
   border: 1px solid rgba(110, 245, 255, 0.25);
   border-radius: 24px;
@@ -75,7 +81,12 @@ body.game-active .app-shell {
   border: none;
   backdrop-filter: none;
   box-shadow: none;
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto 1fr;
+  grid-template-areas:
+    'hud'
+    'board';
+  align-items: stretch;
 }
 
 .hud {
@@ -83,6 +94,7 @@ body.game-active .app-shell {
   flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
+  grid-area: hud;
 }
 
 .hud-actions {
@@ -226,6 +238,7 @@ body.game-active .hud {
 .menu-panels {
   display: grid;
   gap: 1.5rem;
+  grid-area: menu;
 }
 
 .menu-card {
@@ -303,6 +316,16 @@ body[data-ui-state='running'] #pause-button {
 
 .board-wrapper {
   position: relative;
+  grid-area: board;
+  --board-width: 640px;
+  --board-height: 640px;
+  width: min(100%, var(--board-width));
+  max-width: var(--board-width);
+  max-height: min(80vh, var(--board-height));
+  aspect-ratio: calc(var(--board-width) / var(--board-height));
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 24px;
   overflow: hidden;
   border: 1px solid rgba(239, 243, 255, 0.12);
@@ -310,7 +333,7 @@ body[data-ui-state='running'] #pause-button {
 }
 
 body.game-active .board-wrapper {
-  height: 100%;
+  max-height: 100%;
   border-radius: 20px;
 }
 
@@ -352,6 +375,44 @@ body.game-active #game-board {
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
 }
 
+.orientation-guard {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgba(5, 10, 18, 0.88);
+  backdrop-filter: blur(10px);
+  transition: opacity 0.3s ease;
+  z-index: 2;
+}
+
+.orientation-guard.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.orientation-guard .card {
+  background: rgba(10, 14, 22, 0.92);
+  border: 1px solid rgba(110, 245, 255, 0.25);
+  border-radius: 20px;
+  padding: 2rem 2.25rem;
+  text-align: center;
+  max-width: 360px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
+}
+
+.orientation-guard h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.65rem;
+}
+
+.orientation-guard p {
+  margin: 0;
+  color: rgba(239, 243, 255, 0.82);
+  line-height: 1.5;
+}
+
 .overlay h2 {
   margin-top: 0;
   margin-bottom: 0.5rem;
@@ -369,6 +430,7 @@ body.game-active #game-board {
   padding: 1.5rem;
   border: 1px solid rgba(239, 243, 255, 0.08);
   box-shadow: inset 0 0 0 1px rgba(110, 245, 255, 0.05);
+  grid-area: info;
 }
 
 body.game-active .info-panel {
@@ -397,6 +459,78 @@ kbd {
   padding: 0.15rem 0.35rem;
   font-size: 0.85rem;
   box-shadow: 0 2px 0 rgba(239, 243, 255, 0.15);
+}
+
+@media (max-width: 1024px) {
+  .app-shell {
+    width: min(100vw - 1.5rem, 860px);
+  }
+
+  .board-wrapper {
+    max-height: min(70vh, var(--board-height));
+  }
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'hud'
+      'board'
+      'menu'
+      'info';
+  }
+
+  body.game-active .app-shell {
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+      'hud'
+      'board';
+  }
+
+  .hud {
+    justify-content: center;
+  }
+
+  .menu-card {
+    max-width: 100%;
+  }
+
+  .info-panel {
+    order: 3;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    align-items: stretch;
+    justify-content: stretch;
+  }
+
+  .app-shell {
+    padding: clamp(1.25rem, 4vw, 1.75rem);
+    gap: 1.25rem;
+  }
+
+  .hud-actions {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+  }
+
+  .scoreboard {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .board-wrapper {
+    border-radius: 18px;
+  }
+
+  .overlay .card,
+  .orientation-guard .card {
+    padding: 1.5rem;
+  }
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- add FastAPI leaderboard API backed by a JSON store to share high scores across players
- synchronize the game client with the new API while making the board responsive, orientation aware, and keyboard friendly
- refresh layout and styling to support the adaptive board and orientation guard overlay

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e5e60167a883329216b19412c8f8de