### PR TITLE
Persist leaderboard in SQLite database

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,7 +21,7 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 _index_html = (STATIC_DIR / "index.html").read_text(encoding="utf-8")
 
-store = LeaderboardStore(BASE_DIR / "data" / "leaderboard.json", limit=LEADERBOARD_LIMIT)
+store = LeaderboardStore(Path("/data") / "leaderboard.db", limit=LEADERBOARD_LIMIT)
 
 
 class LeaderboardEntryResponse(BaseModel):


### PR DESCRIPTION
## Summary
- replace the JSON-backed leaderboard with a SQLite store saved at `/data/leaderboard.db`
- keep the existing API surface while trimming the table to the configured high score limit

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e5f1b096548332a03ba8465c73fc46