### PR TITLE
Add HUD bonus indicator and ultra bonus

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -16,15 +16,18 @@
     <div class="background-layer"></div>
     <main class="app-shell">
       <header class="hud">
-        <div class="scoreboard">
-          <div class="metric">
-            <span class="label">Score</span>
-            <span id="score-value" class="value">0</span>
+        <div class="hud-metrics">
+          <div class="scoreboard">
+            <div class="metric">
+              <span class="label">Score</span>
+              <span id="score-value" class="value">0</span>
+            </div>
+            <div class="metric">
+              <span class="label">High Score</span>
+              <span id="high-score-value" class="value">0</span>
+            </div>
           </div>
-          <div class="metric">
-            <span class="label">High Score</span>
-            <span id="high-score-value" class="value">0</span>
-          </div>
+          <div id="bonus-indicator" class="bonus-indicator" aria-label="Bonus streak multipliers"></div>
         </div>
         <div class="hud-actions">
           <button id="pause-button" class="btn">Pause</button>

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -97,6 +97,69 @@ body.game-active .app-shell {
   grid-area: hud;
 }
 
+.hud-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.bonus-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  min-height: 2.25rem;
+}
+
+.bonus-indicator-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(14, 18, 28, 0.85);
+  border: 1px solid rgba(110, 245, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(239, 243, 255, 0.05);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+    background 0.2s ease;
+}
+
+.bonus-indicator-item.active {
+  transform: translateY(-1px);
+  border-color: rgba(110, 245, 255, 0.45);
+  box-shadow: 0 10px 24px rgba(110, 245, 255, 0.25);
+}
+
+.bonus-indicator-item.boosted {
+  border-color: rgba(255, 215, 99, 0.55);
+  box-shadow: 0 0 16px rgba(255, 215, 99, 0.35);
+  background: rgba(32, 24, 8, 0.85);
+}
+
+.bonus-icon {
+  --bonus-color-start: rgba(110, 245, 255, 0.95);
+  --bonus-color-end: rgba(186, 110, 255, 0.95);
+  display: grid;
+  place-items: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: 50%;
+  font-weight: 700;
+  font-size: 0.95rem;
+  background: linear-gradient(135deg, var(--bonus-color-start), var(--bonus-color-end));
+  color: rgba(5, 10, 16, 0.9);
+  box-shadow: 0 0 12px rgba(110, 245, 255, 0.4);
+}
+
+.bonus-multiplier {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: rgba(239, 243, 255, 0.85);
+  text-shadow: 0 0 6px rgba(110, 245, 255, 0.35);
+}
+
 .hud-actions {
   margin-left: auto;
 }
@@ -111,6 +174,17 @@ body.game-active .hud {
   padding: 0.75rem 1.5rem;
   border: 1px solid rgba(110, 245, 255, 0.25);
   box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+}
+
+body.game-active .hud-metrics {
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+body.game-active .bonus-indicator {
+  justify-content: flex-start;
 }
 
 .scoreboard {


### PR DESCRIPTION
## Summary
- add a HUD indicator that shows each bonus icon with its current streak multiplier
- introduce a rare ultra bonus that awards higher points per difficulty and expires faster
- scale bonus lifetimes relative to the board size and keep active bonuses in sync when the grid changes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e5f9112d1c833292605b882c76eb30