### PR TITLE
Add difficulty-specific leaderboards and power-up mechanics

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -71,8 +71,12 @@ async def read_index() -> str:
 
 
 @app.get("/api/leaderboard", response_model=LeaderboardPayload)
-async def get_leaderboard(limit: int = Query(10, ge=1, le=LEADERBOARD_LIMIT)) -> LeaderboardPayload:
-    entries = await store.get_entries()
+async def get_leaderboard(
+    limit: int = Query(10, ge=1, le=LEADERBOARD_LIMIT),
+    difficulty: str | None = Query(None),
+) -> LeaderboardPayload:
+    difficulty_filter = ensure_difficulty(difficulty) if difficulty else None
+    entries = await store.get_entries(difficulty=difficulty_filter)
     limited = entries[:limit]
     return LeaderboardPayload(entries=limited, total=len(entries))
 

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -23,11 +23,15 @@
               <span id="score-value" class="value">0</span>
             </div>
             <div class="metric">
-              <span class="label">High Score</span>
+              <span class="label"
+                >High Score
+                <span id="high-score-difficulty-label" class="label-detail"></span
+              ></span>
               <span id="high-score-value" class="value">0</span>
             </div>
           </div>
           <div id="bonus-indicator" class="bonus-indicator" aria-label="Bonus streak multipliers"></div>
+          <div id="power-up-status" class="power-up-status" aria-live="polite"></div>
         </div>
         <div class="hud-actions">
           <button id="pause-button" class="btn">Pause</button>
@@ -37,8 +41,32 @@
       <section id="menu-panels" class="menu-panels">
         <div id="intro-panel" class="menu-card">
           <h2 class="menu-title">Leaderboard</h2>
+          <p id="intro-leaderboard-difficulty" class="leaderboard-subtitle"></p>
+          <div class="leaderboard-controls">
+            <div class="leaderboard-tabs" data-view="intro" role="tablist">
+              <button type="button" class="leaderboard-tab" data-difficulty="easy">Easy</button>
+              <button type="button" class="leaderboard-tab" data-difficulty="medium">Medium</button>
+              <button type="button" class="leaderboard-tab" data-difficulty="hard">Hard</button>
+            </div>
+            <button id="view-leaderboards-button" type="button" class="btn">View Leaderboards</button>
+          </div>
           <ol id="intro-leaderboard" class="leaderboard-list"></ol>
-          <button id="start-button" class="btn primary">Start Game</button>
+          <div class="controls">
+            <button id="start-button" class="btn primary">Start Game</button>
+          </div>
+        </div>
+        <div id="leaderboard-panel" class="menu-card hidden">
+          <h2 class="menu-title">Leaderboards</h2>
+          <p id="leaderboard-panel-difficulty" class="leaderboard-subtitle"></p>
+          <div class="leaderboard-tabs" data-view="panel" role="tablist">
+            <button type="button" class="leaderboard-tab" data-difficulty="easy">Easy</button>
+            <button type="button" class="leaderboard-tab" data-difficulty="medium">Medium</button>
+            <button type="button" class="leaderboard-tab" data-difficulty="hard">Hard</button>
+          </div>
+          <ol id="panel-leaderboard" class="leaderboard-list leaderboard-scroll"></ol>
+          <div class="controls">
+            <button id="leaderboard-back-button" class="btn">Back</button>
+          </div>
         </div>
         <div id="settings-panel" class="menu-card hidden">
           <h2 class="menu-title">Game Settings</h2>
@@ -78,6 +106,7 @@
         </div>
         <div id="postgame-panel" class="menu-card hidden">
           <h2 class="menu-title">Leaderboard</h2>
+          <p id="postgame-leaderboard-difficulty" class="leaderboard-subtitle"></p>
           <ol id="postgame-leaderboard" class="leaderboard-list"></ol>
           <button id="play-again-button" class="btn primary">Play Again</button>
         </div>

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -113,6 +113,56 @@ body.game-active .app-shell {
   min-height: 2.25rem;
 }
 
+.power-up-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  min-height: 1.75rem;
+}
+
+.power-up-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(20, 26, 38, 0.85);
+  border: 1px solid rgba(112, 255, 119, 0.3);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(239, 243, 255, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(112, 255, 119, 0.12);
+}
+
+.power-up-badge[data-kind='invincible'] {
+  border-color: rgba(112, 255, 119, 0.55);
+  box-shadow: 0 0 14px rgba(112, 255, 119, 0.3);
+}
+
+.power-up-badge[data-kind='tail-cut'] {
+  border-color: rgba(255, 215, 99, 0.55);
+  box-shadow: 0 0 14px rgba(255, 215, 99, 0.28);
+}
+
+.power-up-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.power-up-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(239, 243, 255, 0.65);
+}
+
+.power-up-value {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85rem;
+  color: rgba(239, 243, 255, 0.85);
+}
+
 .bonus-indicator-item {
   display: inline-flex;
   align-items: center;
@@ -254,6 +304,15 @@ body.game-active .bonus-indicator {
   color: rgba(239, 243, 255, 0.7);
 }
 
+.metric .label .label-detail {
+  margin-left: 0.35rem;
+  font-size: 0.7rem;
+  letter-spacing: 0;
+  text-transform: none;
+  color: rgba(239, 243, 255, 0.55);
+  font-weight: 500;
+}
+
 .metric .value {
   font-size: 2rem;
   font-weight: 700;
@@ -329,6 +388,78 @@ body.game-active .bonus-indicator {
 
 .menu-card .controls {
   justify-content: flex-end;
+}
+
+.leaderboard-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.leaderboard-controls .btn {
+  min-width: auto;
+}
+
+.leaderboard-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: rgba(12, 18, 28, 0.75);
+  border: 1px solid rgba(110, 245, 255, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(239, 243, 255, 0.05);
+}
+
+.leaderboard-tab {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: rgba(239, 243, 255, 0.7);
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.leaderboard-tab:hover,
+.leaderboard-tab:focus-visible {
+  color: rgba(239, 243, 255, 0.95);
+  outline: none;
+}
+
+.leaderboard-tab.active {
+  background: rgba(110, 245, 255, 0.15);
+  color: #eff3ff;
+  box-shadow: 0 0 12px rgba(110, 245, 255, 0.25);
+}
+
+.leaderboard-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(239, 243, 255, 0.55);
+}
+
+.leaderboard-scroll {
+  max-height: 360px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.leaderboard-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.leaderboard-scroll::-webkit-scrollbar-thumb {
+  background: rgba(110, 245, 255, 0.3);
+  border-radius: 999px;
 }
 
 .menu-title {


### PR DESCRIPTION
## Summary
- split leaderboard storage and API filtering by difficulty so each mode shows its own scores
- revamp the pre-game UI to browse difficulty leaderboards and display difficulty-aware high-score HUD details
- add medium/hard bonus-streak power-ups with invincibility and tail-cut effects, supporting new HUD status indicators and obstacle interactions

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e604ef223083329d1a99a678807f19