### PR TITLE
Add practice and testing modes with improved gameplay UX

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -87,6 +87,8 @@
               <select id="mode-select">
                 <option value="constant">Constant</option>
                 <option value="progressive" selected>Progressive</option>
+                <option value="practice">Practice</option>
+                <option value="testing">Testing</option>
               </select>
             </label>
             <label class="field">
@@ -98,6 +100,73 @@
               </select>
             </label>
             <p id="difficulty-description" class="settings-description"></p>
+            <div id="testing-controls" class="testing-controls hidden" aria-live="polite">
+              <h3 class="testing-title">Testing Overrides</h3>
+              <p class="settings-description">
+                Adjust these values to experiment with different behaviours before starting the
+                round.
+              </p>
+              <label class="field">
+                <span class="field-label">Speed Interval (ms)</span>
+                <input
+                  id="testing-speed-interval"
+                  type="number"
+                  min="55"
+                  max="600"
+                  step="5"
+                  inputmode="numeric"
+                  placeholder="Auto"
+                />
+              </label>
+              <label class="field">
+                <span class="field-label">Obstacle Count</span>
+                <input
+                  id="testing-obstacle-count"
+                  type="number"
+                  min="0"
+                  max="200"
+                  step="1"
+                  inputmode="numeric"
+                  placeholder="Difficulty default"
+                />
+              </label>
+              <label class="field">
+                <span class="field-label">Bonus Spawn Chance (%)</span>
+                <input
+                  id="testing-bonus-chance"
+                  type="number"
+                  min="0"
+                  max="100"
+                  step="1"
+                  inputmode="numeric"
+                  placeholder="Difficulty default"
+                />
+              </label>
+              <label class="field">
+                <span class="field-label">Fruit Value</span>
+                <input
+                  id="testing-fruit-points"
+                  type="number"
+                  min="1"
+                  max="1000"
+                  step="1"
+                  inputmode="numeric"
+                  placeholder="Difficulty default"
+                />
+              </label>
+              <label class="field">
+                <span class="field-label">Power-Up Lifetime (steps)</span>
+                <input
+                  id="testing-powerup-lifetime"
+                  type="number"
+                  min="10"
+                  max="600"
+                  step="1"
+                  inputmode="numeric"
+                  placeholder="Default"
+                />
+              </label>
+            </div>
             <div class="controls">
               <button type="button" id="settings-back-button" class="btn">Back</button>
               <button type="submit" class="btn primary">Begin Run</button>
@@ -120,7 +189,10 @@
             <p id="overlay-message">
               Use the arrow keys, WASD, or swipe on mobile to guide the snake.
             </p>
-            <button id="overlay-button" class="btn primary">Continue</button>
+            <div class="overlay-actions">
+              <button id="overlay-button" class="btn primary">Continue</button>
+              <button id="overlay-secondary-button" class="btn hidden">Secondary</button>
+            </div>
           </div>
         </div>
         <div id="orientation-guard" class="orientation-guard hidden" role="alert" aria-live="assertive">

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -368,6 +368,34 @@ body.game-active .bonus-indicator {
   line-height: 1.4;
 }
 
+.testing-controls {
+  margin-top: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(110, 245, 255, 0.35);
+  background: rgba(10, 16, 26, 0.6);
+  display: grid;
+  gap: 1rem;
+}
+
+.testing-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(239, 243, 255, 0.85);
+}
+
+.testing-controls .field-label {
+  letter-spacing: 0.12em;
+}
+
+.testing-controls .settings-description {
+  margin: 0;
+  color: rgba(239, 243, 255, 0.7);
+}
+
 .menu-panels {
   display: grid;
   gap: 1.5rem;
@@ -578,6 +606,18 @@ body.game-active #game-board {
   text-align: center;
   max-width: 320px;
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+}
+
+.overlay-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.overlay-actions .btn {
+  min-width: 8rem;
 }
 
 .orientation-guard {


### PR DESCRIPTION
## Summary
- show a pre-round overlay so players can preview the board and ensure initial obstacles avoid the snake’s starting path
- queue rapid direction inputs, update snake visuals to reflect power-up activity, and add practice mode with resume/reset handling that skips leaderboard updates
- add a testing mode with configurable gameplay overrides plus UI controls and styling updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9c2ea7e088332bd029e9e5c58a44c